### PR TITLE
Rebrand Chatwoot to CallAPro

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import ChatWootWidget from '@chatwoot/react-native-widget';
+import CallAProWidget from '@chatwoot/react-native-widget';
 
 import {
   SafeAreaView,
@@ -74,10 +74,10 @@ const App = () => {
         <TouchableOpacity
           style={styles.button}
           onPress={() => toggleWidget(true)}>
-          <Text style={styles.buttonText}>Open Chatwoot Widget</Text>
+          <Text style={styles.buttonText}>Open CallAPro Widget</Text>
         </TouchableOpacity>
       </View>
-      <ChatWootWidget
+      <CallAProWidget
         websiteToken={websiteToken}
         locale={locale}
         baseUrl={baseUrl}

--- a/Example/constants.js
+++ b/Example/constants.js
@@ -1,4 +1,4 @@
-export const WOOT_PREFIX = 'chatwoot-widget:';
+export const WOOT_PREFIX = 'callapro-widget:';
 export const POST_MESSAGE_EVENTS = {
   SET_LOCALE: 'set-locale',
   SET_CUSTOM_ATTRIBUTES: 'set-custom-attributes',

--- a/Example/package.json
+++ b/Example/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@chatwoot/react-native-widget": "^0.0.20",
+    "@callapro/react-native-widget": "^0.0.20",
     "@react-native-async-storage/async-storage": "1.23.1",
     "expo": "~51.0.28",
     "expo-status-bar": "~1.12.1",

--- a/Example/src/App.js
+++ b/Example/src/App.js
@@ -24,7 +24,7 @@ const propTypes = {
   closeModal: PropTypes.func,
 };
 
-const ChatWootWidget = ({
+const CallAProWidget = ({
   isModalVisible,
   baseUrl,
   websiteToken,
@@ -74,6 +74,6 @@ const ChatWootWidget = ({
   );
 };
 
-ChatWootWidget.propTypes = propTypes;
+CallAProWidget.propTypes = propTypes;
 
-export default ChatWootWidget;
+export default CallAProWidget;

--- a/Example/src/constants.js
+++ b/Example/src/constants.js
@@ -1,4 +1,4 @@
-export const WOOT_PREFIX = 'chatwoot-widget:';
+export const WOOT_PREFIX = 'callapro-widget:';
 export const POST_MESSAGE_EVENTS = {
   SET_LOCALE: 'set-locale',
   SET_CUSTOM_ATTRIBUTES: 'set-custom-attributes',

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <h1>
-chatwoot-react-native-widget
+callapro-react-native-widget
 </h1>
 
-![](https://img.shields.io/npm/v/@chatwoot/react-native-widget?style=flat)
-![](https://img.shields.io/npm/dt/@chatwoot/react-native-widget.svg)
+![](https://img.shields.io/npm/v/@callapro/react-native-widget?style=flat)
+![](https://img.shields.io/npm/dt/@callapro/react-native-widget.svg)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
-![](https://img.shields.io/npm/l/@chatwoot/@chatwoot/react-native-widget)
+![](https://img.shields.io/npm/l/@callapro/@callapro/react-native-widget)
 
-- **Supported Chatwoot version:** 2.16.0+
+- **Supported CallAPro version:** 2.16.0+
 
 <img src="https://user-images.githubusercontent.com/12408980/203909820-938136a6-bf5b-433e-9f68-d7f28a1303be.png" alt="screenshot" width="350">
 
@@ -16,13 +16,13 @@ chatwoot-react-native-widget
 Install the library using either yarn or npm like so:
 
 ```sh
-yarn add @chatwoot/react-native-widget
+yarn add @callapro/react-native-widget
 ```
 
 OR
 
 ```sh
-npm install --save @chatwoot/react-native-widget
+npm install --save @callapro/react-native-widget
 ```
 
 This library depends on [react-native-webview](https://www.npmjs.com/package/react-native-webview) and [async-storage](https://github.com/react-native-async-storage/async-storage). Please follow the instructions provided in the docs.
@@ -37,7 +37,7 @@ cd ios && pod install
 
 ### How to use
 
-1. Create a website channel in chatwoot server by following the steps described here https://www.chatwoot.com/docs/channels/website
+1. Create a website channel in CallAPro server by following the steps described here https://www.callapro.com/docs/channels/website
 2. Replace `websiteToken` prop and `baseUrl`
 
 ```
@@ -46,7 +46,7 @@ import React, { useState } from 'react';
 
 import { StyleSheet, View, SafeAreaView, TouchableOpacity, Text } from 'react-native';
 
-import ChatWootWidget from '@chatwoot/react-native-widget';
+import CallAProWidget from '@callapro/react-native-widget';
 
 const App = () => {
   const [showWidget, toggleWidget] = useState(false);
@@ -59,7 +59,7 @@ const App = () => {
   };
   const customAttributes = { accountId: 1, pricingPlan: 'paid', status: 'active' };
   const websiteToken = 'WEBSITE_TOKEN';
-  const baseUrl = 'CHATWOOT_INSTALLATION_URL';
+  const baseUrl = 'CALLAPRO_INSTALLATION_URL';
   const locale = 'en';
   const colorScheme='dark'
 
@@ -72,7 +72,7 @@ const App = () => {
       </View>
       {
         showWidget&&
-          <ChatWootWidget
+          <CallAProWidget
             websiteToken={websiteToken}
             locale={locale}
             baseUrl={baseUrl}
@@ -135,7 +135,7 @@ The whole example is in the `/example` folder.
     <td>baseUrl</td>
     <td> - </td>
     <td> String </td>
-    <td>Chatwoot installation URL</td>
+    <td>CallAPro installation URL</td>
   </tr>
  <tr>
     <td>websiteToken</td>
@@ -184,8 +184,8 @@ The whole example is in the `/example` folder.
 
 ## Feedback & Contributing
 
-Feel free to send us feedback on [Twitter](https://twitter.com/chatwootapp) or [file an issue](https://github.com/chatwoot/chatwoot-mobile-app/issues).
+Feel free to send us feedback on [Twitter](https://twitter.com/callaproapp) or [file an issue](https://github.com/callapro/callapro-mobile-app/issues).
 
 If there's anything you'd like to chat about, please feel free to join our [Discord](https://discord.gg/cJXdrwS) chat!
 
-_Chatwoot_ &copy; 2017-2023, Chatwoot Inc - Released under the MIT License.
+_CallAPro_ &copy; 2017-2023, CallAPro Inc - Released under the MIT License.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
-declare module '@chatwoot/react-native-widget' {
+declare module '@callapro/react-native-widget' {
   import React from 'react';
 
-  export interface ChatWootWidgetProps {
+  export interface CallAProWidgetProps {
     websiteToken: string;
     locale?: string;
     baseUrl: string;
@@ -19,6 +19,6 @@ declare module '@chatwoot/react-native-widget' {
     customAttributes?: Record<string, unknown>;
   }
 
-  class ChatWootWidget extends React.Component<ChatWootWidgetProps, any> {}
-  export default ChatWootWidget;
+  class CallAProWidget extends React.Component<CallAProWidgetProps, any> {}
+  export default CallAProWidget;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@chatwoot/react-native-widget",
+  "name": "@callapro/react-native-widget",
   "version": "0.0.21",
-  "description": "React Native widget for Chatwoot",
+  "description": "React Native widget for CallAPro",
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
@@ -40,18 +40,18 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chatwoot/chatwoot-react-native-widget.git"
+    "url": "git+https://github.com/callapro/callapro-react-native-widget.git"
   },
   "keywords": [
     "react-native",
-    "chatwoot",
+    "callapro",
     "mobile",
     "ios",
     "android"
   ],
   "bugs": {
-    "url": "https://github.com/chatwoot/chatwoot-react-native-widget/issues"
+    "url": "https://github.com/callapro/callapro-react-native-widget/issues"
   },
-  "homepage": "https://github.com/chatwoot/chatwoot-react-native-widget#readme",
+  "homepage": "https://github.com/callapro/callapro-react-native-widget#readme",
   "license": "MIT"
 }

--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,7 @@ const propTypes = {
   closeModal: PropTypes.func,
 };
 
-const ChatWootWidget = ({
+const CallAProWidget = ({
   isModalVisible,
   baseUrl,
   websiteToken,
@@ -74,6 +74,6 @@ const ChatWootWidget = ({
   );
 };
 
-ChatWootWidget.propTypes = propTypes;
+CallAProWidget.propTypes = propTypes;
 
-export default ChatWootWidget;
+export default CallAProWidget;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,4 @@
-export const WOOT_PREFIX = 'chatwoot-widget:';
+export const WOOT_PREFIX = 'callapro-widget:';
 export const POST_MESSAGE_EVENTS = {
   SET_LOCALE: 'set-locale',
   SET_CUSTOM_ATTRIBUTES: 'set-custom-attributes',


### PR DESCRIPTION
---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tuhinmallick/chatwoot-react-native-widget/pull/1?shareId=62909d84-8a16-4d99-8350-457c1a7efb60).

## Summary by Sourcery

Chores:
- Rename all project references from 'chatwoot' to 'callapro' across README, package.json, source files, and example project