### PR TITLE
Add Jest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "publish": "npm publish"
   },
   "dependencies": {
@@ -25,7 +25,8 @@
     "husky": "^5.1.3",
     "lint-staged": "^10.5.4",
     "metro-react-native-babel-preset": "^0.65.2",
-    "prettier": "^2.2.1"
+    "prettier": "^2.2.1",
+    "jest": "^27.0.6"
   },
   "husky": {
     "hooks": {

--- a/tests/sample.test.js
+++ b/tests/sample.test.js
@@ -1,0 +1,3 @@
+test('sample test', () => {
+  expect(true).toBe(true);
+});


### PR DESCRIPTION
Add Jest testing framework and a sample test.

* Update the `test` script in `package.json` to `"test": "jest"`.
* Add Jest as a dev dependency in `package.json`.
* Create a `tests` directory in the root of the repository.
* Add a sample test file `tests/sample.test.js` with a simple test case.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tuhinmallick/chatwoot-react-native-widget/pull/6?shareId=1ac9634a-9882-456a-bd37-dcddca924ad4).

## Summary by Sourcery

Set up Jest testing framework for the project

New Features:
- Introduce Jest testing framework to the project

Build:
- Update package.json to configure Jest as the test runner

Tests:
- Add initial Jest testing infrastructure with a sample test case to validate basic testing setup